### PR TITLE
Add Null Separator Option

### DIFF
--- a/file_concat.py
+++ b/file_concat.py
@@ -1,48 +1,105 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import argparse
 from pathlib import Path
 
-def concatenate_files(directory, output_format='markdown'):
+def concatenate_files_from_directory(directory, output_format='markdown'):
     """
     Concatenates all text files in the given directory into a single prompt.
     """
-    result = []
-
     # Get all text files in the directory
     path_obj = Path(directory)
+    file_paths = []
     for file_path in path_obj.iterdir():
         if file_path.is_file() and file_path.suffix in ['.js', '.cs', '.py', '.txt']:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                content = f.read()
+            file_paths.append(file_path)
+    
+    return concatenate_files_from_paths(file_paths, output_format)
 
-                # Format the content based on output format
-                if output_format == 'markdown':
-                    # Add code fence for markdown
-                    language = file_path.suffix[1:]  # Get extension without dot
-                    result.append(f"```{language}\n{content}\n```")
-                elif output_format == 'claude_xml':
-                    # Format as Claude XML
-                    language = file_path.suffix[1:]  # Get extension without dot
-                    result.append(f'<document>\n  <document_content>{content}</document_content>\n  <source>{file_path.name}</source>\n  <language>{language}</language>\n</document>')
-                else:
-                    # Plain text format
-                    result.append(f"--- {file_path.name} ---\n{content}\n")
+def concatenate_files_from_paths(file_paths, output_format='markdown'):
+    """
+    Concatenates files from a list of file paths into a single prompt.
+    """
+    result = []
+
+    for file_path in file_paths:
+        file_path = Path(file_path)
+        if file_path.is_file():
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+
+                    # Format the content based on output format
+                    if output_format == 'markdown':
+                        # Add code fence for markdown
+                        language = file_path.suffix[1:] if file_path.suffix else 'text'
+                        result.append(f"```{language}\n{content}\n```")
+                    elif output_format == 'claude_xml':
+                        # Format as Claude XML
+                        language = file_path.suffix[1:] if file_path.suffix else 'text'
+                        result.append(f'<document>\n  <document_content>{content}</document_content>\n  <source>{file_path.name}</source>\n  <language>{language}</language>\n</document>')
+                    else:
+                        # Plain text format
+                        result.append(f"--- {file_path.name} ---\n{content}\n")
+            except (UnicodeDecodeError, PermissionError) as e:
+                # Skip files that can't be read as text
+                print(f"Skipping {file_path}: {e}", file=sys.stderr)
+                continue
 
     return "\n".join(result)
 
+def read_paths_from_stdin(null_separated=False):
+    """
+    Read file paths from stdin, either newline or null-separated.
+    """
+    if null_separated:
+        # Read all input and split by null character
+        input_data = sys.stdin.buffer.read()
+        paths = input_data.decode('utf-8').split('\0')
+    else:
+        # Read line by line
+        paths = [line.strip() for line in sys.stdin]
+    
+    # Filter out empty paths
+    return [path for path in paths if path.strip()]
+
 def main():
-    parser = argparse.ArgumentParser(description='Concatenate files in a directory into a single prompt.')
-    parser.add_argument('directory', type=str, help='Directory containing the files to concatenate')
+    parser = argparse.ArgumentParser(description='Concatenate files into a single prompt.')
+    parser.add_argument('directory', type=str, nargs='?', help='Directory containing the files to concatenate (optional when using -0/--null)')
     parser.add_argument('-f', '--format', type=str, choices=['markdown', 'text', 'claude_xml'], default='markdown',
                         help='Output format (default: markdown)')
+    parser.add_argument('-0', '--null', action='store_true',
+                        help='Read file paths from stdin, separated by NUL characters (for use with find -print0)')
+    parser.add_argument('-o', '--output', type=str, help='Output file path (default: combined.prompt in directory or current directory)')
     args = parser.parse_args()
 
-    result = concatenate_files(args.directory, args.format)
+    # Determine the mode of operation
+    if args.null:
+        # Read file paths from stdin with null separation
+        file_paths = read_paths_from_stdin(null_separated=True)
+        result = concatenate_files_from_paths(file_paths, args.format)
+        
+        # Determine output path
+        if args.output:
+            output_path = Path(args.output)
+        else:
+            output_path = Path("combined.prompt")
+    else:
+        # Traditional directory mode
+        if not args.directory:
+            parser.error("directory argument is required when not using -0/--null option")
+        
+        result = concatenate_files_from_directory(args.directory, args.format)
+        
+        # Determine output path
+        if args.output:
+            output_path = Path(args.output)
+        else:
+            output_path = Path(args.directory) / "combined.prompt"
 
-    # Output to a .prompt file in the same directory
-    output_path = Path(args.directory) / "combined.prompt"
+    # Write the result to the output file
     with open(output_path, 'w', encoding='utf-8') as f:
         f.write(result)
 


### PR DESCRIPTION
# Add Null Separator Option

This PR implements the feature requested in issue #6.

## Changes Made

- **Added `-0/--null` option**: Read file paths from stdin separated by NUL characters
- **Added `-o/--output` option**: Specify custom output file path
- **Refactored code structure**: Split functionality into separate functions for better maintainability
- **Improved error handling**: Skip files that cannot be read as text with proper error messages
- **Enhanced argument parsing**: Made directory argument optional when using stdin mode

## Usage Examples

### Traditional directory mode (unchanged)
```bash
./file_concat.py sample_files
```

### New null separator mode
```bash
# Use with find -print0
find . -name "*.py" -print0 | ./file_concat.py --null

# With custom output file
find . -name "*.js" -print0 | ./file_concat.py --null -o javascript_files.prompt

# With different format
find . -name "*.txt" -print0 | ./file_concat.py --null -f claude_xml
```

## Testing

- ✅ Tested traditional directory mode - works as before
- ✅ Tested null separator mode with `find -print0`
- ✅ Tested custom output file option
- ✅ Verified help message displays correctly
- ✅ Tested error handling for unreadable files

Fixes #6