### PR TITLE
Add ignore pattern support with --ignore and --ignore-files-only options

### DIFF
--- a/file_concat.py
+++ b/file_concat.py
@@ -3,9 +3,31 @@
 import os
 import sys
 import argparse
+import fnmatch
 from pathlib import Path
 
-def concatenate_files_from_directory(directory, output_format='markdown', extensions=None, include_hidden=False):
+def should_ignore(path, ignore_patterns, ignore_files_only=False):
+    """
+    Check if a path should be ignored based on ignore patterns.
+    """
+    if not ignore_patterns:
+        return False
+    
+    # If ignore_files_only is True and this is a directory, don't ignore it
+    if ignore_files_only and path.is_dir():
+        return False
+    
+    # Check against both the full path and just the name
+    path_str = str(path)
+    name = path.name
+    
+    for pattern in ignore_patterns:
+        if fnmatch.fnmatch(path_str, pattern) or fnmatch.fnmatch(name, pattern):
+            return True
+    
+    return False
+
+def concatenate_files_from_directory(directory, output_format='markdown', extensions=None, include_hidden=False, ignore_patterns=None, ignore_files_only=False):
     """
     Concatenates all text files in the given directory into a single prompt.
     """
@@ -29,11 +51,16 @@ def concatenate_files_from_directory(directory, output_format='markdown', extens
             # Skip hidden files unless include_hidden is True
             if not include_hidden and file_path.name.startswith('.'):
                 continue
+            
+            # Check ignore patterns
+            if should_ignore(file_path, ignore_patterns, ignore_files_only):
+                continue
+                
             file_paths.append(file_path)
     
-    return concatenate_files_from_paths(file_paths, output_format)
+    return concatenate_files_from_paths(file_paths, output_format, ignore_patterns, ignore_files_only)
 
-def concatenate_files_from_paths(file_paths, output_format='markdown'):
+def concatenate_files_from_paths(file_paths, output_format='markdown', ignore_patterns=None, ignore_files_only=False):
     """
     Concatenates files from a list of file paths into a single prompt.
     """
@@ -42,6 +69,9 @@ def concatenate_files_from_paths(file_paths, output_format='markdown'):
     for file_path in file_paths:
         file_path = Path(file_path)
         if file_path.is_file():
+            # Check ignore patterns
+            if should_ignore(file_path, ignore_patterns, ignore_files_only):
+                continue
             try:
                 with open(file_path, 'r', encoding='utf-8') as f:
                     content = f.read()
@@ -90,13 +120,15 @@ def main():
     parser.add_argument('-o', '--output', type=str, help='Output file path (default: combined.prompt in directory or current directory)')
     parser.add_argument('-e', '--extension', action='append', help='File extension to include (can be specified multiple times). Examples: -e txt -e py')
     parser.add_argument('--include-hidden', action='store_true', help='Include hidden files (files starting with .)')
+    parser.add_argument('--ignore', action='append', help='Pattern to ignore (can be specified multiple times). Examples: --ignore "*.log" --ignore "temp*"')
+    parser.add_argument('--ignore-files-only', action='store_true', help='Include directory paths that would otherwise be ignored (only ignore files)')
     args = parser.parse_args()
 
     # Determine the mode of operation
     if args.null:
         # Read file paths from stdin with null separation
         file_paths = read_paths_from_stdin(null_separated=True)
-        result = concatenate_files_from_paths(file_paths, args.format)
+        result = concatenate_files_from_paths(file_paths, args.format, args.ignore, args.ignore_files_only)
         
         # Determine output path
         if args.output:
@@ -108,7 +140,7 @@ def main():
         if not args.directory:
             parser.error("directory argument is required when not using -0/--null option")
         
-        result = concatenate_files_from_directory(args.directory, args.format, args.extension, args.include_hidden)
+        result = concatenate_files_from_directory(args.directory, args.format, args.extension, args.include_hidden, args.ignore, args.ignore_files_only)
         
         # Determine output path
         if args.output:


### PR DESCRIPTION
This PR implements ignore pattern support as requested in Issue #3.

## Changes

- **Added `--ignore` flag**: Supports multiple ignore patterns using fnmatch-style wildcards (e.g., `--ignore "*.log" --ignore "temp*"`)
- **Added `--ignore-files-only` flag**: When used, only files matching ignore patterns are ignored, not directories
- **Implemented `should_ignore()` helper function**: Handles pattern matching logic for both full paths and filenames
- **Updated both directory and stdin modes**: Full support for ignore patterns in all operation modes
- **Added fnmatch import**: Uses Python standard library for robust pattern matching

## Usage Examples

```bash
# Ignore all log files and anything starting with "temp"
python3 file_concat.py /path/to/files --ignore "*.log" --ignore "temp*"

# Only ignore files, not directories matching patterns
python3 file_concat.py /path/to/files --ignore "test*" --ignore-files-only

# Works with stdin mode too
find /path -name "*.py" -print0 | python3 file_concat.py -0 --ignore "*_test.py"
```

## Testing

- ✅ Verified ignore patterns work correctly in directory mode
- ✅ Verified ignore patterns work correctly in stdin mode
- ✅ Confirmed `--ignore-files-only` flag functions as expected
- ✅ Tested multiple ignore patterns
- ✅ Validated help text includes new options

Fixes #3